### PR TITLE
Use no security group ingress rules in module

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -127,11 +127,6 @@ Resources:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
       GroupDescription: !Ref 'AWS::StackName'
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 22
-        ToPort: 22
-        CidrIp: '0.0.0.0/0'
       VpcId:
         'Fn::ImportValue': !Sub '${VpcModule}-Id'
   InstanceProfile:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

I tried to set the custom ingress rule here, but it seems that cloudformation has some problems with passing data between modules, so instead I'll put it to empty and I'll manage the ingress rules in our infra template.